### PR TITLE
perf(hashlife): batch node reads in step_level2_in_store

### DIFF
--- a/src/hashlife.rs
+++ b/src/hashlife.rs
@@ -1060,18 +1060,14 @@ fn center4_in_store(
 fn step_level2_in_store(store: &HashLifeStore, node: NodeId) -> NodeId {
     let table = STEP_LEVEL2_TABLE.get_or_init(build_step_level2_table);
 
-    let (n_nw, n_ne, n_sw, n_se) = {
-        let nodes = store.nodes.lock().unwrap();
-        let n = nodes[node as usize];
-        (n.nw, n.ne, n.sw, n.se)
-    };
     let (nw, ne, sw, se) = {
         let nodes = store.nodes.lock().unwrap();
+        let n = nodes[node as usize];
         (
-            nodes[n_nw as usize],
-            nodes[n_ne as usize],
-            nodes[n_sw as usize],
-            nodes[n_se as usize],
+            nodes[n.nw as usize],
+            nodes[n.ne as usize],
+            nodes[n.sw as usize],
+            nodes[n.se as usize],
         )
     };
 


### PR DESCRIPTION
## Summary

- Merges two sequential `store.nodes.lock()` acquisitions in `step_level2_in_store` into a single lock scope
- The single scope reads the level-2 node's four child `NodeId`s and immediately copies all four child `Node` values before releasing the lock
- Eliminates one mutex round-trip on every level-2 base-case evaluation in `step_recursive` (the innermost hot path)

## Test plan

- [x] All 122 existing tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Benchmarks show no regressions; observed improvements across gosper_gun, cordership_gun, large_soup

## Risk notes

- Pure locking refactor — observable behaviour is identical
- Lock held slightly longer (~5 node reads vs 1) but still O(1); no contention concern
- Deadlock safety preserved: no other lock acquired inside the scope

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)