### PR TITLE
perf(hashlife): replace step_cache Mutex<FxHashMap> with DashMap (issue #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Auto-expand: after each step, if live cells touch any edge, `MARGIN = 20` dead r
 
 - `HashLife` stores the universe as a canonical quadtree; nodes are identified by `NodeId` (`u32` arena index)
 - `CanonTable` — purpose-built open-addressing intern map; 20-byte `CanonEntry {nw,ne,sw,se,id}`, linear probing, 75% load factor, FxHasher on two packed `u64` words; replaces `FxHashMap<(u32,u32,u32,u32),u32>` for better cache locality
-- `step_recursive` — 9-submacrocell algorithm advancing `2^(level−2)` gens, memoised in `step_cache: FxHashMap<NodeId,NodeId>`
+- `step_recursive` — 9-submacrocell algorithm advancing `2^(level−2)` gens, memoised in `step_cache: DashMap<NodeId,NodeId>` (lock-free via sharding)
 - `step_universe` expansion loop checks **two conditions** before each step (both evaluated under a single `nodes` lock per iteration via `needs_expansion_inner` / `needs_expansion_deep_inner`):
   1. `needs_expansion_inner()` — all 12 outer grandchildren must be empty (cells within `[N/4, 3N/4)`)
   2. `needs_expansion_deep_inner()` — all 12 near-boundary great-grandchildren must also be empty (cells within `[3N/8, 5N/8)`); prevents cells near the result-window boundary from being silently dropped during the step for patterns moving at up to c/2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ eframe = { version = "0.33", default-features = false, features = [
     "default_fonts", "wgpu", "wayland",
 ] }
 egui  = "0.33"
+dashmap = "6"
 rayon = "1"
 rfd = "0.17"
 rustc-hash = "2"

--- a/src/hashlife.rs
+++ b/src/hashlife.rs
@@ -7,7 +7,8 @@
 //! The step advances the universe by **2^(level−2)** generations per call —
 //! an exponential speed-up for repetitive/periodic patterns.
 
-use rustc_hash::{FxHashMap, FxHasher};
+use dashmap::DashMap;
+use rustc_hash::FxHasher;
 use std::hash::Hasher;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -241,14 +242,16 @@ pub(crate) const PARALLEL_THRESHOLD: u8 = 6;
 /// Shared mutable state for a HashLife instance, protected behind `Mutex` locks
 /// so that parallel Rayon tasks spawned by `step_recursive` can safely share access.
 ///
-/// Lock ordering (when acquiring both): `nodes` before `canon` before `step_cache`.
+/// Lock ordering (when acquiring both): `nodes` before `canon`.
+/// `step_cache` is lock-free via `DashMap` sharding and requires no explicit ordering.
 struct HashLifeStore {
     /// Arena of all interned nodes; `nodes[0]` = DEAD, `nodes[1]` = ALIVE.
     nodes: Mutex<Vec<Node>>,
     /// Canonicalisation map: `(nw, ne, sw, se)` → `NodeId`.
     canon: Mutex<CanonTable>,
-    /// Memoisation cache for `step_recursive`.
-    step_cache: Mutex<FxHashMap<NodeId, NodeId>>,
+    /// Memoisation cache for `step_recursive`.  Lock-free concurrent access
+    /// via `DashMap` sharding — no `Mutex` required.
+    step_cache: DashMap<NodeId, NodeId, rustc_hash::FxBuildHasher>,
 }
 
 /// Quadtree-memoised Game of Life engine.
@@ -302,7 +305,7 @@ impl HashLife {
         let store = Arc::new(HashLifeStore {
             nodes: Mutex::new(vec![dead_leaf, alive_leaf]),
             canon: Mutex::new(CanonTable::with_capacity(4096)),
-            step_cache: Mutex::new(FxHashMap::default()),
+            step_cache: DashMap::with_hasher(rustc_hash::FxBuildHasher),
         });
         let mut hl = HashLife {
             store,
@@ -352,7 +355,7 @@ impl HashLife {
         let level = self.level;
         let root = self.root;
         self.root = self.set_cell_in(root, row, col, alive, level);
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
     }
 
     /// Toggles the alive/dead state of the cell at absolute `(row, col)`.
@@ -367,7 +370,7 @@ impl HashLife {
     pub(crate) fn clear(&mut self) {
         self.store.nodes.lock().unwrap().truncate(2); // keep DEAD and ALIVE leaves
         self.store.canon.lock().unwrap().clear();
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
         let root = self.make_dead_node(DEFAULT_LEVEL);
         self.root = root;
         self.level = DEFAULT_LEVEL;
@@ -398,7 +401,7 @@ impl HashLife {
                 }
             }
         }
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
     }
 
     /// Clears the grid and centres the given cell offsets, auto-sizing the
@@ -430,7 +433,7 @@ impl HashLife {
         // Reset to a fresh dead root at the required level.
         self.store.nodes.lock().unwrap().truncate(2);
         self.store.canon.lock().unwrap().clear();
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
         let root = self.make_dead_node(level);
         self.root = root;
         self.level = level;
@@ -448,7 +451,7 @@ impl HashLife {
                 self.root = self.set_cell_in(rt, row, col, true, lv);
             }
         }
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
     }
 
     /// Returns all live cells as centred `(row_offset, col_offset)` pairs.
@@ -521,7 +524,7 @@ impl HashLife {
         let j = j.min(62);
         if j != self.step_log2 {
             self.step_log2 = j;
-            self.store.step_cache.lock().unwrap().clear();
+            self.store.step_cache.clear();
         }
     }
 
@@ -641,10 +644,10 @@ impl HashLife {
     ///    and the result node survived; translate IDs through `remap`.
     /// 6. **Commit** — update `self.root`, replace `self.nodes`.
     fn gc(&mut self) {
-        // Lock all three stores for the duration of GC to prevent concurrent access.
+        // Lock nodes and canon for the duration of GC.  step_cache is lock-free
+        // (DashMap) and is drained / rebuilt directly without a Mutex.
         let mut nodes = self.store.nodes.lock().unwrap();
         let mut canon = self.store.canon.lock().unwrap();
-        let mut step_cache = self.store.step_cache.lock().unwrap();
 
         let n = nodes.len();
 
@@ -706,19 +709,21 @@ impl HashLife {
         }
 
         // 5. Remap step_cache: keep entries where both source and result survived.
-        let old_cache = std::mem::take(&mut *step_cache);
-        *step_cache = old_cache
-            .into_iter()
-            .filter_map(|(old_k, old_v)| {
-                let new_k = remap[old_k as usize];
-                let new_v = remap[old_v as usize];
-                if new_k == u32::MAX || new_v == u32::MAX {
-                    None
-                } else {
-                    Some((new_k, new_v))
-                }
-            })
+        // DashMap has no drain(); collect via iter then clear before re-inserting.
+        let old_entries: Vec<(NodeId, NodeId)> = self
+            .store
+            .step_cache
+            .iter()
+            .map(|e| (*e.key(), *e.value()))
             .collect();
+        self.store.step_cache.clear();
+        for (old_k, old_v) in old_entries {
+            let new_k = remap[old_k as usize];
+            let new_v = remap[old_v as usize];
+            if new_k != u32::MAX && new_v != u32::MAX {
+                self.store.step_cache.insert(new_k, new_v);
+            }
+        }
 
         // 6. Commit.
         self.root = remap[self.root as usize];
@@ -1132,12 +1137,9 @@ fn step_level2_in_store(store: &HashLifeStore, node: NodeId) -> NodeId {
 /// single top-level `step_universe` call and the cache is cleared by
 /// `set_step_log2` whenever `j` changes.
 fn step_recursive(store: &Arc<HashLifeStore>, node: NodeId, j: u8) -> NodeId {
-    // Check cache first (without holding the lock during recursion).
-    {
-        let cache = store.step_cache.lock().unwrap();
-        if let Some(&cached) = cache.get(&node) {
-            return cached;
-        }
+    // Check cache first (DashMap — no explicit lock needed).
+    if let Some(cached) = store.step_cache.get(&node) {
+        return *cached;
     }
 
     let level = store.nodes.lock().unwrap()[node as usize].level;
@@ -1240,9 +1242,9 @@ fn step_recursive(store: &Arc<HashLifeStore>, node: NodeId, j: u8) -> NodeId {
         }
     };
 
-    // Insert into cache (double-checked: another thread may have computed this
-    // concurrently; NodeId results are deterministic so either value is correct).
-    store.step_cache.lock().unwrap().insert(node, result);
+    // Insert into cache (DashMap — lock-free; another thread may have computed
+    // this concurrently but NodeId results are deterministic so either value is correct).
+    store.step_cache.insert(node, result);
     result
 }
 


### PR DESCRIPTION
## Summary

- Replaced `step_cache: Mutex<FxHashMap<NodeId,NodeId>>` with `DashMap<NodeId,NodeId,FxBuildHasher>` in `HashLifeStore`
- Eliminated two mutex acquisitions per `step_recursive` call — now lock-free on cache hits via DashMap sharding
- Removed double-checked locking pattern; all 5 `.clear()` call sites simplified
- Updated `gc()` to use `.iter().collect()` + `.clear()` + re-insert (DashMap v6 has no `drain()`)
- Lock-order invariant updated: `nodes → canon` only (step_cache no longer participates)

## Test Plan

- [x] All 122 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #12

🤖 Generated with Claude Code