### PR TITLE
chore(deps): bump wgpu 27 → 28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rfd = "0.17"
 rustc-hash = "2"
 # Re-enable the Vulkan backend: egui-wgpu 0.33 pulls wgpu with
 # default-features = false, so no GPU backend is compiled in otherwise.
-wgpu  = { version = "27", features = ["vulkan"] }
+wgpu  = { version = "28", features = ["vulkan"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }


### PR DESCRIPTION
## Summary

- Bumps `wgpu` version constraint in `Cargo.toml` from `"27"` to `"28"`
- Pulls in wgpu v28.0.0, wgpu-core v28.0.1, wgpu-hal v28.0.1, naga v28.0.0, gpu-allocator v28.0.0, metal v0.33.0, windows bindings v0.62.x

## Test plan

- [ ] `cargo build` passes (verified locally: 20 crates recompiled cleanly)
- [ ] `cargo test` passes
- [ ] App launches and renders correctly with the updated wgpu backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)