### PR TITLE
perf(hashlife): defer GC to idle frames to avoid mid-step UI stalls

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -185,6 +185,10 @@ impl GameOfLifeApp {
     /// capping `dt` at 0.1 s to avoid a large first-frame spike.
     fn advance_simulation(&mut self, ctx: &egui::Context) {
         if !self.sim.running {
+            // Paused idle path: run GC if needed without blocking a step.
+            if self.sim.needs_gc() {
+                self.sim.run_gc();
+            }
             return;
         }
         let dt = (ctx.input(|i| i.unstable_dt) as f64).min(0.1);
@@ -194,6 +198,10 @@ impl GameOfLifeApp {
         self.pop_history.push_back(self.sim.population());
         if self.pop_history.len() > 128 {
             self.pop_history.pop_front();
+        }
+        // Running idle path: run GC once per frame after all steps complete.
+        if self.sim.needs_gc() {
+            self.sim.run_gc();
         }
         ctx.request_repaint();
     }

--- a/src/hashlife.rs
+++ b/src/hashlife.rs
@@ -702,10 +702,6 @@ impl HashLife {
     /// `expansion_per_side` is the number of cells added to each of the four
     /// sides due to `expand_root` calls (used for camera scroll compensation).
     pub(crate) fn step_universe(&mut self) -> (u64, usize) {
-        if self.store.nodes.lock().unwrap().len() > GC_THRESHOLD {
-            self.gc();
-        }
-
         let mut expansion: usize = 0;
 
         // Ensure at least MIN_STEP_LEVEL (and enough room for the requested
@@ -796,6 +792,15 @@ impl HashLife {
 
     // ── Garbage collection ────────────────────────────────────────────────────
 
+    /// Returns `true` when the arena has grown past the GC threshold.
+    ///
+    /// Locks `nodes` briefly; intended to be called from the frame loop so
+    /// that `gc()` can be deferred to an idle window rather than called
+    /// mid-step inside `step_universe`.
+    pub(crate) fn needs_gc(&self) -> bool {
+        self.store.nodes.lock().unwrap().len() > GC_THRESHOLD
+    }
+
     /// Collects unreachable nodes from the arena, compacting it.
     ///
     /// Performs a mark-sweep-compact cycle:
@@ -809,7 +814,7 @@ impl HashLife {
     /// 5. **Remap step_cache** — keep only entries where both the source node
     ///    and the result node survived; translate IDs through `remap`.
     /// 6. **Commit** — update `self.root`, replace `self.nodes`.
-    fn gc(&mut self) {
+    pub(crate) fn gc(&mut self) {
         // Lock all three stores for the duration of GC to prevent concurrent access.
         let mut nodes = self.store.nodes.lock().unwrap();
         let mut canon = self.store.canon.lock().unwrap();
@@ -1818,6 +1823,164 @@ mod tests {
             hl.store.nodes.lock().unwrap().len() < before,
             "GC must reclaim nodes: before={before}, after={}",
             hl.store.nodes.lock().unwrap().len()
+        );
+    }
+
+    // ── needs_gc / deferred-GC tests ─────────────────────────────────────────
+
+    /// `needs_gc()` returns `false` for a freshly created HashLife instance
+    /// (node count << GC_THRESHOLD).
+    #[test]
+    fn test_needs_gc_false_below_threshold() {
+        let hl = HashLife::new();
+        assert!(
+            !hl.needs_gc(),
+            "fresh HashLife arena should be well below GC_THRESHOLD"
+        );
+    }
+
+    /// After a long run the node count eventually exceeds the threshold, at
+    /// which point `needs_gc()` returns `true`.  After calling `gc()` it
+    /// returns `false` again and the population is unchanged.
+    #[test]
+    fn test_needs_gc_true_after_growth_then_false_after_gc() {
+        let mut hl = HashLife::new();
+        // Gosper glider gun – rapidly inflates the arena.
+        let gosper: &[(i32, i32)] = &[
+            (0, 24),
+            (1, 22),
+            (1, 24),
+            (2, 12),
+            (2, 13),
+            (2, 20),
+            (2, 21),
+            (2, 34),
+            (2, 35),
+            (3, 11),
+            (3, 15),
+            (3, 20),
+            (3, 21),
+            (3, 34),
+            (3, 35),
+            (4, 0),
+            (4, 1),
+            (4, 10),
+            (4, 16),
+            (4, 20),
+            (4, 21),
+            (5, 0),
+            (5, 1),
+            (5, 10),
+            (5, 14),
+            (5, 16),
+            (5, 17),
+            (5, 22),
+            (5, 24),
+            (6, 10),
+            (6, 16),
+            (6, 24),
+            (7, 11),
+            (7, 15),
+            (8, 12),
+            (8, 13),
+        ];
+        hl.set_cells(gosper);
+
+        // Keep stepping until the arena exceeds GC_THRESHOLD or until a
+        // reasonable iteration cap to avoid an infinite loop in CI.
+        let mut total = 0u64;
+        let mut hit_threshold = false;
+        while total < 10_000_000 {
+            let (g, _) = hl.step_universe();
+            total += g;
+            if hl.needs_gc() {
+                hit_threshold = true;
+                break;
+            }
+        }
+        assert!(
+            hit_threshold,
+            "arena should exceed GC_THRESHOLD after long run"
+        );
+
+        let pop_before = hl.population();
+        hl.gc();
+        assert!(
+            !hl.needs_gc(),
+            "needs_gc() must return false immediately after gc()"
+        );
+        assert_eq!(
+            hl.population(),
+            pop_before,
+            "gc() must not alter observable population"
+        );
+    }
+
+    /// `step_universe` does NOT call `gc()` internally: after the arena grows
+    /// past the threshold a step must not reduce the node count.
+    #[test]
+    fn test_step_universe_does_not_gc_mid_step() {
+        let mut hl = HashLife::new();
+        let gosper: &[(i32, i32)] = &[
+            (0, 24),
+            (1, 22),
+            (1, 24),
+            (2, 12),
+            (2, 13),
+            (2, 20),
+            (2, 21),
+            (2, 34),
+            (2, 35),
+            (3, 11),
+            (3, 15),
+            (3, 20),
+            (3, 21),
+            (3, 34),
+            (3, 35),
+            (4, 0),
+            (4, 1),
+            (4, 10),
+            (4, 16),
+            (4, 20),
+            (4, 21),
+            (5, 0),
+            (5, 1),
+            (5, 10),
+            (5, 14),
+            (5, 16),
+            (5, 17),
+            (5, 22),
+            (5, 24),
+            (6, 10),
+            (6, 16),
+            (6, 24),
+            (7, 11),
+            (7, 15),
+            (8, 12),
+            (8, 13),
+        ];
+        hl.set_cells(gosper);
+
+        // Advance until arena just exceeds the threshold.
+        let mut total = 0u64;
+        loop {
+            let (g, _) = hl.step_universe();
+            total += g;
+            if hl.needs_gc() {
+                break;
+            }
+            if total > 10_000_000 {
+                panic!("arena never reached GC_THRESHOLD — test is invalid");
+            }
+        }
+
+        let node_count_before = hl.store.nodes.lock().unwrap().len();
+        // One more step must NOT decrease the node count (GC is not inside step_universe).
+        hl.step_universe();
+        let node_count_after = hl.store.nodes.lock().unwrap().len();
+        assert!(
+            node_count_after >= node_count_before,
+            "step_universe must not run GC: before={node_count_before}, after={node_count_after}"
         );
     }
 

--- a/src/hashlife.rs
+++ b/src/hashlife.rs
@@ -1428,6 +1428,46 @@ mod tests {
     // `super::*` resolves differently when included via #[path] in the bench binary
     use super::*;
 
+    /// Gosper glider gun — period 30, emits one glider every 30 generations.
+    const GOSPER_GUN: &[(i32, i32)] = &[
+        (0, 24),
+        (1, 22),
+        (1, 24),
+        (2, 12),
+        (2, 13),
+        (2, 20),
+        (2, 21),
+        (2, 34),
+        (2, 35),
+        (3, 11),
+        (3, 15),
+        (3, 20),
+        (3, 21),
+        (3, 34),
+        (3, 35),
+        (4, 0),
+        (4, 1),
+        (4, 10),
+        (4, 16),
+        (4, 20),
+        (4, 21),
+        (5, 0),
+        (5, 1),
+        (5, 10),
+        (5, 14),
+        (5, 16),
+        (5, 17),
+        (5, 22),
+        (5, 24),
+        (6, 10),
+        (6, 16),
+        (6, 24),
+        (7, 11),
+        (7, 15),
+        (8, 12),
+        (8, 13),
+    ];
+
     // ── Internals ─────────────────────────────────────────────────────────────
 
     /// DEAD and ALIVE are always at fixed indices 0 and 1 with the correct pop.
@@ -1768,45 +1808,7 @@ mod tests {
     fn test_gc_reclaims_nodes() {
         let mut hl = HashLife::new();
         // Gosper glider gun (period 30, emits one glider every 30 gens).
-        let gosper: &[(i32, i32)] = &[
-            (0, 24),
-            (1, 22),
-            (1, 24),
-            (2, 12),
-            (2, 13),
-            (2, 20),
-            (2, 21),
-            (2, 34),
-            (2, 35),
-            (3, 11),
-            (3, 15),
-            (3, 20),
-            (3, 21),
-            (3, 34),
-            (3, 35),
-            (4, 0),
-            (4, 1),
-            (4, 10),
-            (4, 16),
-            (4, 20),
-            (4, 21),
-            (5, 0),
-            (5, 1),
-            (5, 10),
-            (5, 14),
-            (5, 16),
-            (5, 17),
-            (5, 22),
-            (5, 24),
-            (6, 10),
-            (6, 16),
-            (6, 24),
-            (7, 11),
-            (7, 15),
-            (8, 12),
-            (8, 13),
-        ];
-        hl.set_cells(gosper);
+        hl.set_cells(GOSPER_GUN);
 
         // Run until at least 2000 generations to fill the arena with stale
         // intermediate nodes.  Cap by total gens to avoid overflow.
@@ -1846,45 +1848,7 @@ mod tests {
     fn test_needs_gc_true_after_growth_then_false_after_gc() {
         let mut hl = HashLife::new();
         // Gosper glider gun – rapidly inflates the arena.
-        let gosper: &[(i32, i32)] = &[
-            (0, 24),
-            (1, 22),
-            (1, 24),
-            (2, 12),
-            (2, 13),
-            (2, 20),
-            (2, 21),
-            (2, 34),
-            (2, 35),
-            (3, 11),
-            (3, 15),
-            (3, 20),
-            (3, 21),
-            (3, 34),
-            (3, 35),
-            (4, 0),
-            (4, 1),
-            (4, 10),
-            (4, 16),
-            (4, 20),
-            (4, 21),
-            (5, 0),
-            (5, 1),
-            (5, 10),
-            (5, 14),
-            (5, 16),
-            (5, 17),
-            (5, 22),
-            (5, 24),
-            (6, 10),
-            (6, 16),
-            (6, 24),
-            (7, 11),
-            (7, 15),
-            (8, 12),
-            (8, 13),
-        ];
-        hl.set_cells(gosper);
+        hl.set_cells(GOSPER_GUN);
 
         // Keep stepping until the arena exceeds GC_THRESHOLD or until a
         // reasonable iteration cap to avoid an infinite loop in CI.
@@ -1921,45 +1885,7 @@ mod tests {
     #[test]
     fn test_step_universe_does_not_gc_mid_step() {
         let mut hl = HashLife::new();
-        let gosper: &[(i32, i32)] = &[
-            (0, 24),
-            (1, 22),
-            (1, 24),
-            (2, 12),
-            (2, 13),
-            (2, 20),
-            (2, 21),
-            (2, 34),
-            (2, 35),
-            (3, 11),
-            (3, 15),
-            (3, 20),
-            (3, 21),
-            (3, 34),
-            (3, 35),
-            (4, 0),
-            (4, 1),
-            (4, 10),
-            (4, 16),
-            (4, 20),
-            (4, 21),
-            (5, 0),
-            (5, 1),
-            (5, 10),
-            (5, 14),
-            (5, 16),
-            (5, 17),
-            (5, 22),
-            (5, 24),
-            (6, 10),
-            (6, 16),
-            (6, 24),
-            (7, 11),
-            (7, 15),
-            (8, 12),
-            (8, 13),
-        ];
-        hl.set_cells(gosper);
+        hl.set_cells(GOSPER_GUN);
 
         // Advance until arena just exceeds the threshold.
         let mut total = 0u64;
@@ -2213,50 +2139,11 @@ mod tests {
     /// constructed instances — confirming the sequential path is unaffected.
     #[test]
     fn test_parallel_small_pattern_gosper_gun_correctness() {
-        let gosper: &[(i32, i32)] = &[
-            (0, 24),
-            (1, 22),
-            (1, 24),
-            (2, 12),
-            (2, 13),
-            (2, 20),
-            (2, 21),
-            (2, 34),
-            (2, 35),
-            (3, 11),
-            (3, 15),
-            (3, 20),
-            (3, 21),
-            (3, 34),
-            (3, 35),
-            (4, 0),
-            (4, 1),
-            (4, 10),
-            (4, 16),
-            (4, 20),
-            (4, 21),
-            (5, 0),
-            (5, 1),
-            (5, 10),
-            (5, 14),
-            (5, 16),
-            (5, 17),
-            (5, 22),
-            (5, 24),
-            (6, 10),
-            (6, 16),
-            (6, 24),
-            (7, 11),
-            (7, 15),
-            (8, 12),
-            (8, 13),
-        ];
-
         // Two independent HashLife instances must agree exactly.
         let mut hl1 = HashLife::new();
-        hl1.set_cells(gosper);
+        hl1.set_cells(GOSPER_GUN);
         let mut hl2 = HashLife::new();
-        hl2.set_cells(gosper);
+        hl2.set_cells(GOSPER_GUN);
 
         let mut total1 = 0u64;
         let mut total2 = 0u64;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -198,6 +198,28 @@ impl Simulation {
         matches!(self.engine, Engine::HashLife(_))
     }
 
+    /// Returns `true` when the active engine's node arena needs garbage
+    /// collection.
+    ///
+    /// Always returns `false` for the SWAR engine.  For HashLife, delegates
+    /// to [`HashLife::needs_gc`].
+    pub(crate) fn needs_gc(&self) -> bool {
+        match &self.engine {
+            Engine::Swar(_) => false,
+            Engine::HashLife(hl) => hl.needs_gc(),
+        }
+    }
+
+    /// Runs a garbage-collection cycle on the active engine if applicable.
+    ///
+    /// No-op for the SWAR engine.  For HashLife, calls [`HashLife::gc`] to
+    /// compact the arena and free unreachable nodes.
+    pub(crate) fn run_gc(&mut self) {
+        if let Engine::HashLife(hl) = &mut self.engine {
+            hl.gc();
+        }
+    }
+
     // ── Lifecycle methods ─────────────────────────────────────────────────────
 
     /// Loads centred cell offsets as the new grid state, resets the generation
@@ -498,6 +520,49 @@ mod tests {
         sim.pattern_name = Some("glider".to_owned());
         sim.fill_random(50);
         assert!(sim.pattern_name.is_none());
+    }
+
+    // ── GC proxy tests ────────────────────────────────────────────────────────
+
+    /// `needs_gc()` always returns `false` for the SWAR engine.
+    #[test]
+    fn test_needs_gc_false_for_swar() {
+        let sim = Simulation::new();
+        assert!(!sim.is_hashlife(), "precondition: default engine is SWAR");
+        assert!(!sim.needs_gc(), "needs_gc must always be false for SWAR");
+    }
+
+    /// `run_gc()` on the SWAR engine must not panic.
+    #[test]
+    fn test_run_gc_noop_for_swar() {
+        let mut sim = Simulation::new();
+        assert!(!sim.is_hashlife());
+        sim.run_gc(); // must not panic
+    }
+
+    /// `needs_gc()` returns `false` for a freshly created HashLife engine
+    /// (arena is tiny, well below threshold).
+    #[test]
+    fn test_needs_gc_false_for_fresh_hashlife() {
+        let mut sim = Simulation::new();
+        sim.toggle_engine();
+        assert!(sim.is_hashlife());
+        assert!(!sim.needs_gc(), "fresh HashLife engine should not need GC");
+    }
+
+    /// `run_gc()` on HashLife must not panic and must preserve population.
+    #[test]
+    fn test_run_gc_preserves_hashlife_population() {
+        let mut sim = Simulation::new();
+        sim.toggle_engine();
+        sim.load_cells(&[(0, -1), (0, 0), (0, 1)]); // blinker
+        let pop_before = sim.population();
+        sim.run_gc();
+        assert_eq!(
+            sim.population(),
+            pop_before,
+            "run_gc must not alter population"
+        );
     }
 
     /// toggle_engine() does NOT clear pattern_name.


### PR DESCRIPTION
## Summary
- Removed the inline `gc()` call from `step_universe` — GC no longer stalls the simulation hot path
- Added `pub(crate) needs_gc()` (cheap ~10 ns lock check) and exposed `pub(crate) gc()` on `HashLife`
- Added `needs_gc()` / `run_gc()` proxy methods on `Simulation` (no-op for SWAR engine)
- GC now fires at most once per frame: after the step loop completes (running path) or in the early-return branch (paused path) inside `advance_simulation`
- 7 new tests covering both engines and the deferred-GC behaviour

## Test Plan
- [x] All 143 existing tests pass
- [x] New tests cover: `needs_gc` threshold, GC reduces node count, mid-step GC no longer fires, SWAR no-op
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` passes

## Benchmark Results

```
hashlife/cordership_gun_step_universe  time: [3.9062 ms 4.0708 ms 4.1709 ms]
hashlife/large_soup_1gen               time: [2.9441 ms 3.0742 ms 3.1492 ms]
canon_probe/canon_probe_warm_small     time: [17.067 µs 17.241 µs 17.400 µs]
canon_probe/canon_probe_warm_large     time: [3.4475 ms 3.5247 ms 3.5655 ms]
```

Closes #11

🤖 Generated with Claude Code