### PR TITLE
feat(ui): rectangular selection, copy, paste, and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ and rendered via wgpu on Wayland.
 - **Drag-and-drop** — drag a `.rle` or `.cells` file directly onto the window to load and
   centre it instantly; unsupported file types show a dismissible error message
 
+### Selection, copy & paste
+- **Rectangular selection** — hold `Shift` and drag to draw a selection rectangle over any region of the grid
+- **Copy** — `Ctrl+C` copies all live cells inside the current selection to the clipboard as relative offsets
+- **Paste** — `Ctrl+V` enters paste mode; ghost cells follow the cursor to preview placement; left-click to commit
+- **Delete** — `Delete` erases all live cells inside the selection and clears it
+- **Cancel** — `Escape` clears the selection and cancels any pending paste
+
 ### UI extras
 - **Keyboard cheat-sheet** — `F1` toggles an overlay listing all shortcuts
 - **Pattern name display** — the name of the currently loaded pattern (from the browser or a file) is shown in the top panel next to the generation counter; it is cleared when the grid is edited, cleared, or randomly filled
@@ -111,6 +118,11 @@ make release bump=major        # … major version
 | `0` | Reset zoom to 100 % |
 | `Ctrl+scroll` | Zoom in / out (mouse-anchored) |
 | `Middle-drag` | Pan viewport |
+| `Shift+drag` | Rectangular selection |
+| `Ctrl+C` | Copy selection |
+| `Ctrl+V` | Paste clipboard (click to place) |
+| `Delete` | Delete selection |
+| `Escape` | Clear selection / cancel paste |
 | `F1` | Show / hide keyboard cheat-sheet |
 
 ---

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,11 @@ const SHORTCUTS: &[(&str, &str)] = &[
     ("F1", "Show / hide this cheat-sheet"),
     ("Ctrl+scroll", "Zoom in / out"),
     ("Middle-drag", "Pan viewport"),
+    ("Shift+drag", "Rectangular selection"),
+    ("Ctrl+C", "Copy selection"),
+    ("Ctrl+V", "Paste clipboard (click to place)"),
+    ("Delete", "Delete selection"),
+    ("Escape", "Clear selection / cancel paste"),
 ];
 
 /// An entry in the filtered, unified browser list.
@@ -83,6 +88,17 @@ pub struct GameOfLifeApp {
     /// Error message from the last failed drag-and-drop file load, shown as a
     /// dismissible window at the bottom of the screen.
     pub(crate) drop_error: Option<String>,
+    /// Currently active rectangular selection as inclusive grid coordinates
+    /// `[rmin, cmin, rmax, cmax]`, or `None` when no selection is active.
+    pub(crate) selection: Option<[usize; 4]>,
+    /// Grid coordinate where the user began dragging a rectangular selection.
+    pub(crate) selection_drag_start: Option<(usize, usize)>,
+    /// Clipboard: live cells copied from the last `copy_selection` call,
+    /// stored as `(row_offset, col_offset)` relative to the selection top-left.
+    pub(crate) clipboard: Vec<(i64, i64)>,
+    /// Anchor (top-left grid cell) for the pending paste preview, or `None`
+    /// when no paste is in progress.
+    pub(crate) paste_anchor: Option<(usize, usize)>,
 }
 
 impl GameOfLifeApp {
@@ -112,6 +128,10 @@ impl GameOfLifeApp {
             browser_entries_search: String::new(),
             preview_textures: HashMap::new(),
             drop_error: None,
+            selection: None,
+            selection_drag_start: None,
+            clipboard: Vec::new(),
+            paste_anchor: None,
         };
         app.rebuild_browser_entries();
         app
@@ -268,12 +288,90 @@ impl GameOfLifeApp {
         let dt = (ctx.input(|i| i.unstable_dt) as f64).min(0.1);
         let (t, l) = self.sim.advance(dt);
         self.camera.apply_expansion(t, l);
+        self.shift_selection(t, l);
         // Track live-cell population history (max 128 samples).
         self.pop_history.push_back(self.sim.population());
         if self.pop_history.len() > 128 {
             self.pop_history.pop_front();
         }
         ctx.request_repaint();
+    }
+}
+
+// ── Selection / clipboard ─────────────────────────────────────────────────────
+
+impl GameOfLifeApp {
+    /// Copies all live cells within `self.selection` into `self.clipboard` as
+    /// `(row_offset, col_offset)` pairs relative to the selection's top-left
+    /// corner `(rmin, cmin)`.  Does nothing when `self.selection` is `None`.
+    pub(crate) fn copy_selection(&mut self) {
+        let [rmin, cmin, rmax, cmax] = match self.selection {
+            Some(s) => s,
+            None => return,
+        };
+        let live = self
+            .sim
+            .live_cells_in_viewport(rmin, cmin, rmax + 1, cmax + 1);
+        self.clipboard = live
+            .into_iter()
+            .map(|(r, c)| (r as i64 - rmin as i64, c as i64 - cmin as i64))
+            .collect();
+    }
+
+    /// Erases every live cell that falls within `self.selection`, then clears
+    /// `self.selection`.  Does nothing when `self.selection` is `None`.
+    pub(crate) fn delete_selection(&mut self) {
+        let [rmin, cmin, rmax, cmax] = match self.selection {
+            Some(s) => s,
+            None => return,
+        };
+        let live = self
+            .sim
+            .live_cells_in_viewport(rmin, cmin, rmax + 1, cmax + 1);
+        for (r, c) in live {
+            self.sim.set(r, c, false);
+        }
+        self.selection = None;
+    }
+
+    /// Places the clipboard cells into the grid at absolute position
+    /// `(anchor_row, anchor_col)`.  Clipboard offsets that would land outside
+    /// the grid bounds are silently skipped.  Does nothing when
+    /// `self.clipboard` is empty.
+    pub(crate) fn commit_paste(&mut self, anchor_row: usize, anchor_col: usize) {
+        let width = self.sim.width();
+        let height = self.sim.height();
+        for &(dr, dc) in &self.clipboard {
+            let r = anchor_row as i64 + dr;
+            let c = anchor_col as i64 + dc;
+            if r < 0 || c < 0 || r as usize >= height || c as usize >= width {
+                continue;
+            }
+            self.sim.set(r as usize, c as usize, true);
+        }
+    }
+
+    /// Shifts the selection, drag-start, and paste-anchor coordinates after a
+    /// grid auto-expansion.
+    ///
+    /// Called from `advance_simulation` with the `(add_top, add_left)` values
+    /// returned by `sim.advance` so that the selection rectangle stays aligned
+    /// with the same logical cells after the grid grows.
+    pub(crate) fn shift_selection(&mut self, add_top: usize, add_left: usize) {
+        if let Some(ref mut sel) = self.selection {
+            sel[0] += add_top;
+            sel[2] += add_top;
+            sel[1] += add_left;
+            sel[3] += add_left;
+        }
+        if let Some(ref mut start) = self.selection_drag_start {
+            start.0 += add_top;
+            start.1 += add_left;
+        }
+        if let Some(ref mut anchor) = self.paste_anchor {
+            anchor.0 += add_top;
+            anchor.1 += add_left;
+        }
     }
 }
 
@@ -313,6 +411,10 @@ impl GameOfLifeApp {
             browser_entries_search: String::new(),
             preview_textures: HashMap::new(),
             drop_error: None,
+            selection: None,
+            selection_drag_start: None,
+            clipboard: Vec::new(),
+            paste_anchor: None,
         };
         app.rebuild_browser_entries();
         app
@@ -504,6 +606,147 @@ mod tests {
         assert!(
             result.is_ok(),
             ".RLE uppercase extension should be accepted"
+        );
+    }
+
+    // ── Selection / copy / paste tests ────────────────────────────────────────
+
+    /// Helper: place a set of (row, col) live cells into `app.sim`.
+    fn place_cells(app: &mut GameOfLifeApp, cells: &[(usize, usize)]) {
+        for &(r, c) in cells {
+            app.sim.set(r, c, true);
+        }
+    }
+
+    /// copy_selection copies exactly the live cells inside the selection as
+    /// relative (dr, dc) offsets from (rmin, cmin).
+    #[test]
+    fn test_copy_selection_basic() {
+        let mut app = GameOfLifeApp::new_for_test();
+        // Place three live cells: two inside selection, one outside.
+        place_cells(&mut app, &[(2, 3), (2, 5), (10, 10)]);
+        // Selection covers rows 2..=4, cols 3..=6 — captures (2,3) and (2,5).
+        app.selection = Some([2, 3, 4, 6]);
+        app.copy_selection();
+        let mut got = app.clipboard.clone();
+        got.sort_unstable();
+        // Expected relative offsets: (2-2, 3-3)=(0,0) and (2-2, 5-3)=(0,2).
+        let mut expected: Vec<(i64, i64)> = vec![(0, 0), (0, 2)];
+        expected.sort_unstable();
+        assert_eq!(
+            got, expected,
+            "clipboard should contain only cells inside selection as relative offsets"
+        );
+    }
+
+    /// copy_selection with no live cells inside the selection yields an empty clipboard.
+    #[test]
+    fn test_copy_selection_empty_region() {
+        let mut app = GameOfLifeApp::new_for_test();
+        // Live cells are entirely outside the selection.
+        place_cells(&mut app, &[(20, 20), (30, 30)]);
+        app.selection = Some([0, 0, 5, 5]);
+        app.copy_selection();
+        assert!(
+            app.clipboard.is_empty(),
+            "clipboard must be empty when selection contains no live cells"
+        );
+    }
+
+    /// delete_selection erases cells inside the selection and leaves cells
+    /// outside untouched; selection is cleared afterwards.
+    #[test]
+    fn test_delete_selection_erases_inside_and_preserves_outside() {
+        let mut app = GameOfLifeApp::new_for_test();
+        // Cells inside selection at (3,3) and (4,4); outside at (10,10).
+        place_cells(&mut app, &[(3, 3), (4, 4), (10, 10)]);
+        app.selection = Some([3, 3, 5, 5]);
+        app.delete_selection();
+        assert!(
+            !app.sim.get(3, 3),
+            "cell (3,3) inside selection must be dead after delete"
+        );
+        assert!(
+            !app.sim.get(4, 4),
+            "cell (4,4) inside selection must be dead after delete"
+        );
+        assert!(
+            app.sim.get(10, 10),
+            "cell (10,10) outside selection must remain alive"
+        );
+        assert!(
+            app.selection.is_none(),
+            "selection must be cleared after delete_selection"
+        );
+    }
+
+    /// commit_paste places clipboard cells at the given anchor.
+    #[test]
+    fn test_commit_paste_basic() {
+        let mut app = GameOfLifeApp::new_for_test();
+        // Manually load clipboard: relative offsets (0,0) and (1,2).
+        app.clipboard = vec![(0, 0), (1, 2)];
+        // Paste at anchor (5, 7).
+        app.commit_paste(5, 7);
+        assert!(
+            app.sim.get(5, 7),
+            "cell (5,7) = anchor + (0,0) must be alive after paste"
+        );
+        assert!(
+            app.sim.get(6, 9),
+            "cell (6,9) = anchor + (1,2) must be alive after paste"
+        );
+    }
+
+    /// copy → delete → paste at the same origin reproduces the original pattern.
+    #[test]
+    fn test_copy_paste_round_trip() {
+        let mut app = GameOfLifeApp::new_for_test();
+        // Place an L-shaped pattern inside a 5×5 selection at (2,2).
+        let original: Vec<(usize, usize)> = vec![(2, 2), (3, 2), (4, 2), (4, 3)];
+        place_cells(&mut app, &original);
+        app.selection = Some([2, 2, 6, 6]);
+        // Step 1: copy.
+        app.copy_selection();
+        // Step 2: delete.
+        app.selection = Some([2, 2, 6, 6]);
+        app.delete_selection();
+        // Verify all original cells are gone.
+        for &(r, c) in &original {
+            assert!(
+                !app.sim.get(r, c),
+                "cell ({r},{c}) must be dead after delete"
+            );
+        }
+        // Step 3: paste back at original top-left (2,2).
+        app.commit_paste(2, 2);
+        // Verify original pattern is reproduced.
+        for &(r, c) in &original {
+            assert!(
+                app.sim.get(r, c),
+                "cell ({r},{c}) must be alive after round-trip paste"
+            );
+        }
+    }
+
+    /// commit_paste near the grid edge silently skips out-of-bounds offsets.
+    #[test]
+    fn test_commit_paste_out_of_bounds_skips_without_panic() {
+        let mut app = GameOfLifeApp::new_for_test();
+        // Grid is 100×60 by default (GRID_COLS × GRID_ROWS).
+        // Anchor at bottom-right corner; offsets (0,0), (5,10), (100,200) — last two OOB.
+        app.clipboard = vec![(0, 0), (5, 10), (100, 200)];
+        let height = app.sim.height();
+        let width = app.sim.width();
+        // Anchor near the bottom-right so that large offsets go OOB.
+        let anchor_row = height.saturating_sub(3);
+        let anchor_col = width.saturating_sub(3);
+        // Must not panic.
+        app.commit_paste(anchor_row, anchor_col);
+        // The (0,0) offset should be alive (anchor itself is in bounds).
+        assert!(
+            app.sim.get(anchor_row, anchor_col),
+            "in-bounds cell at anchor must be alive after paste"
         );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,7 +19,20 @@ use crate::camera::{DEFAULT_CELL_SIZE, ZOOM_STEP};
 /// * `app` — mutable application state
 /// * `ctx` — egui context for reading input
 pub(crate) fn handle_keyboard(app: &mut GameOfLifeApp, ctx: &egui::Context) {
-    let (toggle, step, clear, grid_lines, help, zoom_in, zoom_out, zoom_reset) = ctx.input(|i| {
+    let (
+        toggle,
+        step,
+        clear,
+        grid_lines,
+        help,
+        zoom_in,
+        zoom_out,
+        zoom_reset,
+        copy,
+        paste,
+        delete,
+        escape,
+    ) = ctx.input(|i| {
         (
             i.key_pressed(Key::Space),
             i.key_pressed(Key::S) && !app.sim.running,
@@ -29,6 +42,10 @@ pub(crate) fn handle_keyboard(app: &mut GameOfLifeApp, ctx: &egui::Context) {
             i.key_pressed(Key::Equals) || i.key_pressed(Key::Plus),
             i.key_pressed(Key::Minus),
             i.key_pressed(Key::Num0),
+            i.key_pressed(Key::C) && i.modifiers.ctrl,
+            i.key_pressed(Key::V) && i.modifiers.ctrl,
+            i.key_pressed(Key::Delete),
+            i.key_pressed(Key::Escape),
         )
     });
     if toggle {
@@ -37,6 +54,7 @@ pub(crate) fn handle_keyboard(app: &mut GameOfLifeApp, ctx: &egui::Context) {
     if step {
         let (t, l) = app.sim.step_once();
         app.camera.apply_expansion(t, l);
+        app.shift_selection(t, l);
     }
     if clear {
         app.sim.clear();
@@ -46,6 +64,20 @@ pub(crate) fn handle_keyboard(app: &mut GameOfLifeApp, ctx: &egui::Context) {
     }
     if help {
         app.show_help = !app.show_help;
+    }
+    if copy {
+        app.copy_selection();
+    }
+    if paste && !app.clipboard.is_empty() {
+        app.paste_anchor = Some((0, 0));
+    }
+    if delete {
+        app.delete_selection();
+    }
+    if escape {
+        app.selection = None;
+        app.selection_drag_start = None;
+        app.paste_anchor = None;
     }
     let center = app.camera.viewport_rect.size() / 2.0;
     if zoom_in {

--- a/src/ui/grid_view.rs
+++ b/src/ui/grid_view.rs
@@ -14,6 +14,14 @@ const COLOR_DEAD: Color32 = Color32::from_gray(45);
 const GRID_LINE_MIN_CELL_SIZE: f32 = 4.0;
 /// Colour for grid lines.
 const COLOR_GRID_LINE: Color32 = Color32::from_gray(60);
+/// Colour for the rectangular selection overlay border.
+const COLOR_SELECTION: Color32 = Color32::from_rgba_premultiplied(100, 180, 255, 180);
+/// Colour for ghost (paste-preview) cells.
+const COLOR_GHOST: Color32 = Color32::from_rgba_premultiplied(180, 230, 100, 120);
+/// Filled dash length in logical pixels for the selection border.
+const DASH_FILLED_PX: f32 = 6.0;
+/// Gap length in logical pixels for the selection border.
+const DASH_GAP_PX: f32 = 4.0;
 
 /// Draws the central grid canvas and handles mouse drag-painting.
 ///
@@ -48,6 +56,10 @@ pub(crate) fn draw_grid(app: &mut GameOfLifeApp, ui: &mut egui::Ui) {
         paint_grid_lines(app, &painter, origin, viewport);
     }
 
+    // Draw selection overlay and ghost paste-preview cells.
+    paint_selection_overlay(app, &painter, origin);
+    paint_ghost_cells(app, &painter, origin);
+
     // Show cell coordinate tooltip on hover.
     if let Some(hover_pos) = response.hover_pos()
         && let Some((row, col)) =
@@ -70,37 +82,71 @@ pub(crate) fn draw_grid(app: &mut GameOfLifeApp, ui: &mut egui::Ui) {
 fn handle_mouse(app: &mut GameOfLifeApp, response: &egui::Response, origin: Pos2) {
     let (w, h) = (app.sim.width(), app.sim.height());
 
-    // Handle single click (press+release without drag)
+    // Read whether Shift is currently held.
+    let shift_held = response.ctx.input(|i| i.modifiers.shift);
+
+    // Update paste anchor to follow the hovered cell when paste mode is active.
+    if app.paste_anchor.is_some()
+        && let Some(pos) = response.hover_pos()
+        && let Some((row, col)) = app.camera.pos_to_cell(pos, origin, w, h)
+    {
+        app.paste_anchor = Some((row, col));
+    }
+
+    // Left-click (no drag) while in paste mode: commit paste at hover cell.
     if response.clicked()
         && let Some(pos) = response.interact_pointer_pos()
         && let Some((row, col)) = app.camera.pos_to_cell(pos, origin, w, h)
     {
-        app.sim.toggle(row, col);
-        app.sim.pattern_name = None;
+        if app.paste_anchor.is_some() {
+            app.commit_paste(row, col);
+            app.paste_anchor = None;
+        } else if !shift_held {
+            app.sim.toggle(row, col);
+            app.sim.pattern_name = None;
+        }
     }
 
+    // Primary drag start.
     if response.drag_started_by(PointerButton::Primary)
         && let Some(pos) = response.interact_pointer_pos()
         && let Some((row, col)) = app.camera.pos_to_cell(pos, origin, w, h)
     {
-        // The new state is the opposite of the current cell state
-        let old_state = app.sim.get(row, col);
-        app.drag_paint_state = Some(!old_state);
-        app.sim.toggle(row, col);
-        app.sim.pattern_name = None;
+        if shift_held {
+            // Begin rectangular selection; suppress normal paint.
+            app.selection_drag_start = Some((row, col));
+            app.selection = Some([row, col, row, col]);
+            app.drag_paint_state = None;
+            app.paste_anchor = None;
+        } else {
+            // Clear any existing selection and begin paint.
+            app.selection = None;
+            app.selection_drag_start = None;
+            let old_state = app.sim.get(row, col);
+            app.drag_paint_state = Some(!old_state);
+            app.sim.toggle(row, col);
+            app.sim.pattern_name = None;
+        }
     }
 
+    // Primary drag in progress.
     if response.dragged_by(PointerButton::Primary)
-        && let (Some(pos), Some(paint_alive)) =
-            (response.interact_pointer_pos(), app.drag_paint_state)
+        && let Some(pos) = response.interact_pointer_pos()
         && let Some((row, col)) = app.camera.pos_to_cell(pos, origin, w, h)
     {
-        app.sim.set(row, col, paint_alive);
-        app.sim.pattern_name = None;
+        if let Some((sr, sc)) = app.selection_drag_start {
+            // Extend selection rectangle.
+            app.selection = Some([sr.min(row), sc.min(col), sr.max(row), sc.max(col)]);
+        } else if let Some(paint_alive) = app.drag_paint_state {
+            app.sim.set(row, col, paint_alive);
+            app.sim.pattern_name = None;
+        }
     }
 
+    // Primary drag stopped.
     if response.drag_stopped_by(PointerButton::Primary) {
         app.drag_paint_state = None;
+        app.selection_drag_start = None;
     }
 
     // Middle-button pan: record start position.
@@ -202,5 +248,79 @@ fn paint_grid_lines(app: &GameOfLifeApp, painter: &Painter, origin: Pos2, viewpo
     for col in col_min..col_max {
         let x = origin.x + col as f32 * s;
         painter.line_segment([Pos2::new(x, y_start), Pos2::new(x, y_end)], stroke);
+    }
+}
+
+/// Draws a dashed rectangular border around `app.selection`, if any.
+///
+/// Each side is subdivided into alternating filled (`DASH_FILLED_PX`) and
+/// gap (`DASH_GAP_PX`) segments drawn with [`Painter::line_segment`].
+///
+/// # Arguments
+/// * `app`     — application state (read-only access to selection and camera)
+/// * `painter` — egui painter for the grid canvas
+/// * `origin`  — screen-space top-left corner of the grid canvas
+fn paint_selection_overlay(app: &GameOfLifeApp, painter: &Painter, origin: Pos2) {
+    let [rmin, cmin, rmax, cmax] = match app.selection {
+        Some(s) => s,
+        None => return,
+    };
+    let s = app.camera.cell_size;
+    let x0 = origin.x + cmin as f32 * s;
+    let y0 = origin.y + rmin as f32 * s;
+    let x1 = origin.x + (cmax + 1) as f32 * s;
+    let y1 = origin.y + (rmax + 1) as f32 * s;
+
+    let stroke = Stroke::new(1.5, COLOR_SELECTION);
+    paint_dashed_segment(painter, Pos2::new(x0, y0), Pos2::new(x1, y0), stroke);
+    paint_dashed_segment(painter, Pos2::new(x1, y0), Pos2::new(x1, y1), stroke);
+    paint_dashed_segment(painter, Pos2::new(x1, y1), Pos2::new(x0, y1), stroke);
+    paint_dashed_segment(painter, Pos2::new(x0, y1), Pos2::new(x0, y0), stroke);
+}
+
+/// Draws a dashed line from `a` to `b` using alternating filled/gap segments.
+fn paint_dashed_segment(painter: &Painter, a: Pos2, b: Pos2, stroke: Stroke) {
+    let total = (b - a).length();
+    if total < 1e-3 {
+        return;
+    }
+    let dir = (b - a) / total;
+    let period = DASH_FILLED_PX + DASH_GAP_PX;
+    let mut dist = 0.0f32;
+    while dist < total {
+        let dash_end = (dist + DASH_FILLED_PX).min(total);
+        painter.line_segment([a + dir * dist, a + dir * dash_end], stroke);
+        dist += period;
+    }
+}
+
+/// Draws ghost (semi-transparent) cells showing where the clipboard would be
+/// pasted at `app.paste_anchor`.
+///
+/// # Arguments
+/// * `app`     — application state (read-only access to clipboard, paste_anchor, camera)
+/// * `painter` — egui painter for the grid canvas
+/// * `origin`  — screen-space top-left corner of the grid canvas
+fn paint_ghost_cells(app: &GameOfLifeApp, painter: &Painter, origin: Pos2) {
+    let (anchor_row, anchor_col) = match app.paste_anchor {
+        Some(a) => a,
+        None => return,
+    };
+    if app.clipboard.is_empty() {
+        return;
+    }
+    let s = app.camera.cell_size;
+    let fill_size = if s > CELL_GAP_PX { s - CELL_GAP_PX } else { s };
+    let (w, h) = (app.sim.width(), app.sim.height());
+    for &(dr, dc) in &app.clipboard {
+        let r = anchor_row as i64 + dr;
+        let c = anchor_col as i64 + dc;
+        if r < 0 || c < 0 || r as usize >= h || c as usize >= w {
+            continue;
+        }
+        let x = origin.x + c as f32 * s;
+        let y = origin.y + r as f32 * s;
+        let rect = Rect::from_min_size(Pos2::new(x, y), Vec2::splat(fill_size));
+        painter.rect_filled(rect, 0.0, COLOR_GHOST);
     }
 }


### PR DESCRIPTION
## Summary
- Shift+drag creates a visible rectangular selection overlay on the grid canvas
- `Ctrl+C` copies all live cells within the selection as relative offsets into a clipboard buffer
- `Ctrl+V` enters paste mode: ghost cells follow the cursor for preview; left-click to commit placement
- `Delete` erases all live cells inside the selection and clears it
- `Escape` clears the active selection or cancels an in-progress paste

## Test Plan
- [x] All existing 144 tests still pass
- [x] 6 new unit tests cover copy, delete, paste, round-trip, and out-of-bounds safety
- [x] Lint (`cargo clippy -- -D warnings`) clean
- [x] Format (`cargo fmt --check`) clean

Closes #27

🤖 Generated with Claude Code