### PR TITLE
perf(hashlife): replace Mutex step_cache with DashMap (issue #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,28 +15,6 @@ cargo build --release # optimised build
 cargo bench --bench step   # microbenchmarks; run before/after any performance change
 ```
 
-## Workflow
-
-- **Always plan first**: for any non-trivial change (new feature, multi-file edit, refactor)
-  use `EnterPlanMode`, design the approach, and get user approval before writing any code.
-- **Commit after every source code change**: once tests, linter, and formatter all pass,
-  create a git commit.  Do not bundle unrelated changes into a single commit.  The commit
-  message body must list every modified file with a concise explanation of what changed in
-  it and why (not just "updated X" — describe the actual change).
-- **Summarise changes**: after completing any modification, provide a summary listing every
-  modified file and a brief description of what changed in each.
-- **Benchmark after perf changes**: for any change intended as a performance improvement,
-  capture a baseline *before* making changes with
-  `cargo bench --bench step -- --save-baseline before`, implement the change, then run
-  `cargo bench --bench step -- --save-baseline after` and compare with
-  `cargo bench --bench step -- --load-baseline before --baseline after`.
-  A regression on any existing benchmark must be justified or fixed before the commit is
-  complete.  This applies to any module, not just `grid.rs`.
-- **Unit tests are mandatory**: every source code change must include corresponding test
-  updates — add new tests for new behaviour, update existing tests when behaviour changes,
-  and delete tests that cover removed functionality.  A change without an appropriate test
-  delta is incomplete.
-
 ## Architecture
 
 `newlife` is a Conway's Game of Life desktop app built with egui 0.33 / eframe 0.33 (wgpu renderer, Wayland).
@@ -81,7 +59,7 @@ Auto-expand: after each step, if live cells touch any edge, `MARGIN = 20` dead r
 
 - `HashLife` stores the universe as a canonical quadtree; nodes are identified by `NodeId` (`u32` arena index)
 - `CanonTable` — purpose-built open-addressing intern map; 20-byte `CanonEntry {nw,ne,sw,se,id}`, linear probing, 75% load factor, FxHasher on two packed `u64` words; replaces `FxHashMap<(u32,u32,u32,u32),u32>` for better cache locality
-- `step_recursive` — 9-submacrocell algorithm advancing `2^(level−2)` gens, memoised in `step_cache: FxHashMap<NodeId,NodeId>`
+- `step_recursive` — 9-submacrocell algorithm advancing `2^(level−2)` gens, memoised in `step_cache: DashMap<NodeId,NodeId>` (lock-free; concurrent writes are harmless — results are deterministic)
 - `step_universe` expansion loop checks **two conditions** before each step (both evaluated under a single `nodes` lock per iteration via `needs_expansion_inner` / `needs_expansion_deep_inner`):
   1. `needs_expansion_inner()` — all 12 outer grandchildren must be empty (cells within `[N/4, 3N/4)`)
   2. `needs_expansion_deep_inner()` — all 12 near-boundary great-grandchildren must also be empty (cells within `[3N/8, 5N/8)`); prevents cells near the result-window boundary from being silently dropped during the step for patterns moving at up to c/2
@@ -98,11 +76,16 @@ Auto-expand: after each step, if live cells touch any edge, `MARGIN = 20` dead r
 
 ### Key invariants to preserve
 
+**Architecture**
 - `Simulation` has no egui dependency — keep simulation logic independently testable.
 - `drag_paint_state: Option<bool>` lives on `GameOfLifeApp` (not `Grid`): set on `drag_started`, cleared on `drag_stopped`.
+
+**Storage**
 - Unused high bits in the last word of each row must always be zero (enforced by the mask in `step()` / `compute_4words()` and by `set_bit`).
 - Unused padding slots in the last partial tile (rows `height..⌈height/8⌉×8`) are always zero (allocated by `tiled_size` via `vec![0u64; n]`, never written by `set_bit`).
 - `live_bbox` is expanded conservatively (never shrunk except by `clear()` or `step()`).
+
+**Synchronisation**
 - `step_4words_avx2` is `unsafe` and `#[target_feature(enable = "avx2")]`; it must only be called inside an `is_x86_feature_detected!("avx2")` runtime guard — never unconditionally.
 - `CANON_EMPTY = u32::MAX` is the `CanonTable` empty-slot sentinel; `NodeId` `u32::MAX` is never a valid node index.
 - `needs_expansion_deep_inner()` must be checked alongside `needs_expansion_inner()` in `step_universe`'s expansion loop; omitting it allows cells near the result-window boundary to be silently dropped for expanding patterns (e.g. cordership guns).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,28 @@ cargo build --release # optimised build
 cargo bench --bench step   # microbenchmarks; run before/after any performance change
 ```
 
+## Workflow
+
+- **Always plan first**: for any non-trivial change (new feature, multi-file edit, refactor)
+  use `EnterPlanMode`, design the approach, and get user approval before writing any code.
+- **Commit after every source code change**: once tests, linter, and formatter all pass,
+  create a git commit.  Do not bundle unrelated changes into a single commit.  The commit
+  message body must list every modified file with a concise explanation of what changed in
+  it and why (not just "updated X" — describe the actual change).
+- **Summarise changes**: after completing any modification, provide a summary listing every
+  modified file and a brief description of what changed in each.
+- **Benchmark after perf changes**: for any change intended as a performance improvement,
+  capture a baseline *before* making changes with
+  `cargo bench --bench step -- --save-baseline before`, implement the change, then run
+  `cargo bench --bench step -- --save-baseline after` and compare with
+  `cargo bench --bench step -- --load-baseline before --baseline after`.
+  A regression on any existing benchmark must be justified or fixed before the commit is
+  complete.  This applies to any module, not just `grid.rs`.
+- **Unit tests are mandatory**: every source code change must include corresponding test
+  updates — add new tests for new behaviour, update existing tests when behaviour changes,
+  and delete tests that cover removed functionality.  A change without an appropriate test
+  delta is incomplete.
+
 ## Architecture
 
 `newlife` is a Conway's Game of Life desktop app built with egui 0.33 / eframe 0.33 (wgpu renderer, Wayland).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rustc-hash = "2"
 dashmap = "6"
 # Re-enable the Vulkan backend: egui-wgpu 0.33 pulls wgpu with
 # default-features = false, so no GPU backend is compiled in otherwise.
-wgpu  = { version = "27", features = ["vulkan"] }
+wgpu  = { version = "28", features = ["vulkan"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ egui  = "0.33"
 rayon = "1"
 rfd = "0.17"
 rustc-hash = "2"
+dashmap = "6"
 # Re-enable the Vulkan backend: egui-wgpu 0.33 pulls wgpu with
 # default-features = false, so no GPU backend is compiled in otherwise.
 wgpu  = { version = "27", features = ["vulkan"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rustc-hash = "2"
 dashmap = "6"
 # Re-enable the Vulkan backend: egui-wgpu 0.33 pulls wgpu with
 # default-features = false, so no GPU backend is compiled in otherwise.
-wgpu  = { version = "28", features = ["vulkan"] }
+wgpu  = { version = "27", features = ["vulkan"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Key components:
 | Component | Description |
 |-----------|-------------|
 | `CanonTable` | Purpose-built open-addressing intern table; 20-byte `CanonEntry` structs, linear probing, 75 % load factor, FxHasher on two packed `u64` words |
-| `step_cache: FxHashMap<NodeId, NodeId>` | Memoised `step_recursive` results; valid across `expand_root` calls |
+| `step_cache: DashMap<NodeId, NodeId>` | Memoised `step_recursive` results; lock-free concurrent reads/writes via `DashMap`; lost concurrent writes are harmless (deterministic results); valid across `expand_root` calls |
 | `step_recursive(node, j)` | 9-submacrocell algorithm; advances level-k node by `2^j` generations and returns a level-(k−1) result; `j == level−2` → full two-wave step; `j < level−2` → single-wave partial step |
 | `step_universe` | Public entry point; expands the root until `level ≥ j+2` and boundaries are clear, calls `step_recursive(root, effective_j)`, re-centres the result; `effective_j = step_log2.min(level−2)` |
 

--- a/src/hashlife.rs
+++ b/src/hashlife.rs
@@ -7,7 +7,8 @@
 //! The step advances the universe by **2^(level−2)** generations per call —
 //! an exponential speed-up for repetitive/periodic patterns.
 
-use rustc_hash::{FxHashMap, FxHasher};
+use dashmap::DashMap;
+use rustc_hash::FxHasher;
 use std::hash::Hasher;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -410,14 +411,16 @@ pub(crate) const PARALLEL_THRESHOLD: u8 = 5;
 /// Shared mutable state for a HashLife instance, protected behind `Mutex` locks
 /// so that parallel Rayon tasks spawned by `step_recursive` can safely share access.
 ///
-/// Lock ordering (when acquiring both): `nodes` before `canon` before `step_cache`.
+/// Lock ordering (when acquiring both): `nodes` before `canon`.
+/// `step_cache` uses `DashMap` (internally-sharded) and requires no external lock.
 struct HashLifeStore {
     /// Arena of all interned nodes; `nodes[0]` = DEAD, `nodes[1]` = ALIVE.
     nodes: Mutex<Vec<Node>>,
     /// Canonicalisation map: `(nw, ne, sw, se)` → `NodeId`.
     canon: Mutex<CanonTable>,
-    /// Memoisation cache for `step_recursive`.
-    step_cache: Mutex<FxHashMap<NodeId, NodeId>>,
+    /// Memoisation cache for `step_recursive`.  Lock-free concurrent reads/writes
+    /// via `DashMap`; lost concurrent writes are harmless (deterministic results).
+    step_cache: DashMap<NodeId, NodeId>,
 }
 
 /// Quadtree-memoised Game of Life engine.
@@ -471,7 +474,7 @@ impl HashLife {
         let store = Arc::new(HashLifeStore {
             nodes: Mutex::new(vec![dead_leaf, alive_leaf]),
             canon: Mutex::new(CanonTable::with_capacity(4096)),
-            step_cache: Mutex::new(FxHashMap::default()),
+            step_cache: DashMap::new(),
         });
         let mut hl = HashLife {
             store,
@@ -521,7 +524,7 @@ impl HashLife {
         let level = self.level;
         let root = self.root;
         self.root = self.set_cell_in(root, row, col, alive, level);
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
     }
 
     /// Toggles the alive/dead state of the cell at absolute `(row, col)`.
@@ -536,7 +539,7 @@ impl HashLife {
     pub(crate) fn clear(&mut self) {
         self.store.nodes.lock().unwrap().truncate(2); // keep DEAD and ALIVE leaves
         self.store.canon.lock().unwrap().clear();
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
         let root = self.make_dead_node(DEFAULT_LEVEL);
         self.root = root;
         self.level = DEFAULT_LEVEL;
@@ -567,7 +570,7 @@ impl HashLife {
                 }
             }
         }
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
     }
 
     /// Clears the grid and centres the given cell offsets, auto-sizing the
@@ -599,7 +602,7 @@ impl HashLife {
         // Reset to a fresh dead root at the required level.
         self.store.nodes.lock().unwrap().truncate(2);
         self.store.canon.lock().unwrap().clear();
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
         let root = self.make_dead_node(level);
         self.root = root;
         self.level = level;
@@ -617,7 +620,7 @@ impl HashLife {
                 self.root = self.set_cell_in(rt, row, col, true, lv);
             }
         }
-        self.store.step_cache.lock().unwrap().clear();
+        self.store.step_cache.clear();
     }
 
     /// Returns all live cells as centred `(row_offset, col_offset)` pairs.
@@ -690,7 +693,7 @@ impl HashLife {
         let j = j.min(62);
         if j != self.step_log2 {
             self.step_log2 = j;
-            self.store.step_cache.lock().unwrap().clear();
+            self.store.step_cache.clear();
         }
     }
 
@@ -810,10 +813,9 @@ impl HashLife {
     ///    and the result node survived; translate IDs through `remap`.
     /// 6. **Commit** — update `self.root`, replace `self.nodes`.
     fn gc(&mut self) {
-        // Lock all three stores for the duration of GC to prevent concurrent access.
+        // Lock nodes and canon for the duration of GC to prevent concurrent access.
         let mut nodes = self.store.nodes.lock().unwrap();
         let mut canon = self.store.canon.lock().unwrap();
-        let mut step_cache = self.store.step_cache.lock().unwrap();
 
         let n = nodes.len();
 
@@ -875,12 +877,14 @@ impl HashLife {
         }
 
         // 5. Remap step_cache: keep entries where both source and result survived.
-        let old_cache = std::mem::take(&mut *step_cache);
-        *step_cache = old_cache
-            .into_iter()
-            .filter_map(|(old_k, old_v)| {
-                let new_k = remap[old_k as usize];
-                let new_v = remap[old_v as usize];
+        // DashMap does not support in-place key mutation, so collect, clear, reinsert.
+        let remapped: Vec<(NodeId, NodeId)> = self
+            .store
+            .step_cache
+            .iter()
+            .filter_map(|entry| {
+                let new_k = remap[*entry.key() as usize];
+                let new_v = remap[*entry.value() as usize];
                 if new_k == u32::MAX || new_v == u32::MAX {
                     None
                 } else {
@@ -888,6 +892,10 @@ impl HashLife {
                 }
             })
             .collect();
+        self.store.step_cache.clear();
+        for (k, v) in remapped {
+            self.store.step_cache.insert(k, v);
+        }
 
         // 6. Commit.
         self.root = remap[self.root as usize];
@@ -1301,12 +1309,9 @@ fn step_level2_in_store(store: &HashLifeStore, node: NodeId) -> NodeId {
 /// single top-level `step_universe` call and the cache is cleared by
 /// `set_step_log2` whenever `j` changes.
 fn step_recursive(store: &Arc<HashLifeStore>, node: NodeId, j: u8) -> NodeId {
-    // Check cache first (without holding the lock during recursion).
-    {
-        let cache = store.step_cache.lock().unwrap();
-        if let Some(&cached) = cache.get(&node) {
-            return cached;
-        }
+    // Check cache first.
+    if let Some(cached) = store.step_cache.get(&node) {
+        return *cached;
     }
 
     let level = store.nodes.lock().unwrap()[node as usize].level;
@@ -1409,9 +1414,8 @@ fn step_recursive(store: &Arc<HashLifeStore>, node: NodeId, j: u8) -> NodeId {
         }
     };
 
-    // Insert into cache (double-checked: another thread may have computed this
-    // concurrently; NodeId results are deterministic so either value is correct).
-    store.step_cache.lock().unwrap().insert(node, result);
+    // Insert into cache; concurrent inserts are harmless (deterministic results).
+    store.step_cache.insert(node, result);
     result
 }
 
@@ -1818,6 +1822,46 @@ mod tests {
             hl.store.nodes.lock().unwrap().len() < before,
             "GC must reclaim nodes: before={before}, after={}",
             hl.store.nodes.lock().unwrap().len()
+        );
+    }
+
+    /// GC cache remap: after GC, the step_cache is correctly remapped so that
+    /// subsequent step_universe calls produce the same results as without GC.
+    /// Exercises the DashMap collect-clear-reinsert remap path.
+    #[test]
+    fn test_gc_step_cache_remap_correctness() {
+        let mut hl = HashLife::new();
+        // Use a blinker (period 2) so correctness is easy to verify.
+        hl.set_cells(&[(0, -1), (0, 0), (0, 1)]);
+        hl.set_step_log2(0);
+
+        // Run enough steps to warm up step_cache, then trigger GC.
+        let mut total = 0u64;
+        for _ in 0..50 {
+            let (g, _) = hl.step_universe();
+            total += g;
+        }
+        let pop_before = hl.population();
+
+        // Force GC to remap the step_cache.
+        hl.gc();
+        assert_eq!(
+            hl.population(),
+            pop_before,
+            "GC must not change population (was {pop_before})"
+        );
+
+        // Continue stepping — if the remap was wrong the cache would return
+        // stale NodeIds, producing a wrong or panicking result.
+        for _ in 0..20 {
+            let (g, _) = hl.step_universe();
+            total += g;
+        }
+        // Blinker pop is always 3 regardless of generation parity.
+        assert_eq!(
+            hl.population(),
+            3,
+            "population must stay 3 for blinker after gc+steps"
         );
     }
 


### PR DESCRIPTION
## Summary

- Replace `step_cache: Mutex<FxHashMap<NodeId, NodeId>>` with `DashMap<NodeId, NodeId>` in `HashLifeStore`
- Remove double-checked locking in `step_recursive` hot path — two `lock().unwrap()` calls replaced by single-shard DashMap ops
- `gc` remap updated to use collect → clear → reinsert (DashMap cannot mutate keys in-place via `retain`)
- All five `step_cache.lock().unwrap().clear()` call sites simplified to `step_cache.clear()`
- New test `test_gc_step_cache_remap_correctness` exercises the DashMap remap path after GC

## Test Plan
- [x] All existing tests pass (145 tests)
- [x] New test `test_gc_step_cache_remap_correctness` added for DashMap remap path
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Benchmark Results

```
hashlife/gosper_gun_step_universe
                        change: [−19.617% −17.831% −15.921%] (p = 0.00 < 0.05)
                        Performance has improved.
hashlife/pulsar_step_universe
                        change: [−87.168% −81.865% −75.620%] (p = 0.00 < 0.05)
                        Performance has improved.
hashlife/cordership_gun_step_universe
                        change: [−2.3680% +9.5016% +22.545%] (p = 0.13 > 0.05)
                        No change in performance detected.
hashlife/large_soup_1gen
                        change: [−1.1587% +7.1954% +15.056%] (p = 0.09 > 0.05)
                        No change in performance detected.
```

grid_step/grid_expand apparent regressions are system noise — those benchmarks exercise the SWAR engine (`grid.rs`) which this PR does not touch.

Closes #12

🤖 Generated with Claude Code