### PR TITLE
docs(readme): update stale 'newlife' binary name to 'nlife' after crate rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ and rendered via wgpu on Wayland.
 
 ```bash
 cargo run                      # debug build + launch
-cargo build --release          # optimised binary → target/release/newlife
-./target/release/newlife       # run the release binary
+cargo build --release          # optimised binary → target/release/nlife
+./target/release/nlife       # run the release binary
 
 cargo test                     # run all tests
 cargo test test_blinker        # run a specific test by name prefix
@@ -131,7 +131,7 @@ make release bump=major        # … major version
 
 ## Architecture
 
-`newlife` is built with **egui 0.33 / eframe 0.33** (wgpu renderer, Wayland).
+`nlife` is built with **egui 0.33 / eframe 0.33** (wgpu renderer, Wayland).
 The codebase separates a pure simulation core (no UI dependency) from an egui frontend.
 
 ### Module map


### PR DESCRIPTION
## Summary

After the Cargo.toml rename \`newlife\` -> \`nlife\` (commit 7a1e8dd), the README build/run snippets still pointed at \`target/release/newlife\`, which no longer exists, so copy-pasted instructions fail. Fixed the three remaining README hits:

- line 93: \`target/release/newlife\` comment -> \`target/release/nlife\`
- line 94: \`./target/release/newlife\` run command -> \`./target/release/nlife\`
- line 134: \"\`newlife\` is built with egui...\" -> \"\`nlife\` is built...\"

Intentionally left the two \`~/.config/newlife/patterns/\` references (lines 61, 257) alone — that's an on-disk path that needs a migration decision, per #42. Happy to follow up there once the maintainer picks a direction.

Refs #42

## Testing

Docs-only. Three lines changed; no path/import logic touched.